### PR TITLE
Fix some error handling + an edge case for card parsing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,7 @@ const { program } = require("@caporal/core");
 
 function formatError(e) {
   return chalk.red(
-    error.stack.replace(
+    e.stack.replace(
       // Retain underlining node_modules in error stack
       /\/node_modules\/([\w\d_-]+)/g,
       "/node_modules/" + chalk.underline("$1")
@@ -273,7 +273,7 @@ program
         } catch (e) {
           console.error(
             chalk.red(
-              `An error was thrown while converting ${doc.metadata.slug}!`
+              `An error was thrown while converting ${htmlFile}!`
             )
           );
           console.error(formatError(e));

--- a/src/h2m/handlers/cards.js
+++ b/src/h2m/handlers/cards.js
@@ -46,7 +46,7 @@ const extractLabel = (children, t, labelText) => {
       if (labelText.includes(toText(firstChild).trim())) {
         // First child is already the proper label
         childrenToAdd = asArray(t(children.slice(1)));
-      } else if (labelText.includes(toText(firstChild).trim() + ":")) {
+      } else if (labelText.includes(toText(firstChild).trim() + ":") && children[1].value !== undefined) {
         // The colon is outside of the first child
         childrenToAdd = [
           h("text", " "),


### PR DESCRIPTION
When trying to convert/cleanup (dry-run) the `ru` `Mozilla` section, the converter crashed on https://github.com/mdn/translated-content/blob/main/files/ru/mozilla/add-ons/webextensions/api/cookies/cookie/index.html#L68 because: 

- the keyword is the one in the localizations for `ru`
- the `<strong>` element is not properly enclosed inside a `<p>` (this shouldn't happen… in theory…)
- the colon is not in the `<strong>` element

Along the way, I've fixed two other issues:

- one being a kind of typo (`e` vs `error`), please let me know if there's something obvious I missed,
- the other being the exception relying on `doc` being available, which is not the case since the matching `try` is located before its declaration

## STR

```
yarn run h2m mozilla --locale ru --mode dry --verbose
```
(with mdn/translated-content as of https://github.com/mdn/translated-content/commit/99a73b79947a93c56e3154aea784b2b88139ff3c)